### PR TITLE
Fix Japanese comment in Dockerfiles

### DIFF
--- a/project/learning_Sales_summary/docker/Dockerfile
+++ b/project/learning_Sales_summary/docker/Dockerfile
@@ -9,7 +9,7 @@ FROM python:3.11-slim AS app-stage
 # 作業ディレクトリ
 WORKDIR /app
 
-#TODO: 存関係インストール 
+#TODO: 依存関係インストール
 COPY ../requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 #RUN pip install fastapi uvicorn python-multipart pytz pandas pytest pytest-asyncio

--- a/project/learning_Sales_summary/docker/Dockerfile-dev
+++ b/project/learning_Sales_summary/docker/Dockerfile-dev
@@ -9,7 +9,7 @@ FROM python:3.11-slim AS app-stage
 # 作業ディレクトリ
 WORKDIR /app
 
-#TODO: 存関係インストール 
+#TODO: 依存関係インストール
 COPY ../requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 #RUN pip install fastapi uvicorn python-multipart pytz pandas pytest pytest-asyncio


### PR DESCRIPTION
## Summary
- fix Japanese comment about dependencies in Dockerfile and Dockerfile-dev

## Testing
- `pip install -r project/learning_Sales_summary/requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_683f861f6f98832898e615026b7b7470