### PR TITLE
Add simple nginx proxy example

### DIFF
--- a/project/simple_reverse_proxy/README.md
+++ b/project/simple_reverse_proxy/README.md
@@ -1,0 +1,20 @@
+# simple_reverse_proxy
+
+This sample demonstrates using **nginx** as a reverse proxy in front of a small FastAPI backend.
+
+## Usage
+
+1. Build and start the containers:
+   ```bash
+   docker-compose up --build
+   ```
+2. Open `http://localhost` in your browser. Click the "取得" button to fetch data from the backend.
+
+The backend will respond with the plain string `AAA`.
+
+## Structure
+
+- `backend/` - FastAPI application and Dockerfile
+- `frontend/` - Static HTML/JavaScript served by nginx
+- `nginx/` - nginx configuration
+- `docker-compose.yml` - compose file running nginx and the backend

--- a/project/simple_reverse_proxy/backend/Dockerfile
+++ b/project/simple_reverse_proxy/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py .
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/project/simple_reverse_proxy/backend/app.py
+++ b/project/simple_reverse_proxy/backend/app.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI, Response
+
+app = FastAPI()
+
+@app.get("/api/aaa")
+def read_aaa():
+    return Response(content="AAA", media_type="text/plain")

--- a/project/simple_reverse_proxy/backend/requirements.txt
+++ b/project/simple_reverse_proxy/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/project/simple_reverse_proxy/docker-compose.yml
+++ b/project/simple_reverse_proxy/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+services:
+  backend:
+    build: ./backend
+    container_name: simple_backend
+    expose:
+      - "8000"
+    networks:
+      - appnet
+  nginx:
+    image: nginx:latest
+    container_name: simple_nginx
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
+      - ./frontend:/usr/share/nginx/html
+    depends_on:
+      - backend
+    networks:
+      - appnet
+networks:
+  appnet:

--- a/project/simple_reverse_proxy/frontend/index.html
+++ b/project/simple_reverse_proxy/frontend/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>AAA Fetcher</title>
+    <script>
+        async function fetchAAA() {
+            const res = await fetch('/api/aaa');
+            const text = await res.text();
+            document.getElementById('result').innerText = text;
+        }
+    </script>
+</head>
+<body>
+    <button id="fetchButton" onclick="fetchAAA()">取得</button>
+    <div id="result"></div>
+</body>
+</html>

--- a/project/simple_reverse_proxy/nginx/default.conf
+++ b/project/simple_reverse_proxy/nginx/default.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html;
+        try_files $uri $uri/ =404;
+    }
+
+    location /api/ {
+        proxy_pass http://backend:8000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}


### PR DESCRIPTION
## Summary
- add `simple_reverse_proxy` example project with FastAPI backend and nginx reverse proxy
- include basic HTML/JS frontend calling `/api/aaa`

## Testing
- `pip install -r project/learning_Sales_summary/requirements.txt`
- `pip install httpx`
- `PYTHONPATH=project/learning_Sales_summary pytest project/learning_Sales_summary/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d7eff9248328825c67aa86956641