### PR TITLE
Enable debug mode for simple_reverse_proxy

### DIFF
--- a/project/simple_reverse_proxy/.vscode/launch.json
+++ b/project/simple_reverse_proxy/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Attach to Backend",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 5678
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}/backend",
+                    "remoteRoot": "/app"
+                }
+            ]
+        }
+    ]
+}

--- a/project/simple_reverse_proxy/backend/Dockerfile
+++ b/project/simple_reverse_proxy/backend/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY app.py .
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["python", "-m", "debugpy", "--listen", "0.0.0.0:5678", "--wait-for-client", "-m", "uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/project/simple_reverse_proxy/backend/requirements.txt
+++ b/project/simple_reverse_proxy/backend/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+debugpy

--- a/project/simple_reverse_proxy/docker-compose.yml
+++ b/project/simple_reverse_proxy/docker-compose.yml
@@ -3,8 +3,11 @@ services:
   backend:
     build: ./backend
     container_name: simple_backend
-    expose:
-      - "8000"
+    ports:
+      - "8000:8000"
+      - "5678:5678"
+    volumes:
+      - ./backend:/app
     networks:
       - appnet
   nginx:


### PR DESCRIPTION
## Summary
- allow attaching a debugger to the backend container
- expose debug port in docker compose
- provide VS Code launch configuration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848dca4c430832898c2983a29de9a04